### PR TITLE
Add PostgreSQL support and database selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ USERNAME='ユーザ名'
 PASSWORD='パスワード'
 HOST='ホスト名(AWSでいえばRDSのDNS)'
 DB_NAME='接続DB名'
+DB_TYPE='mysql' # or 'postgresql'
 ```
 
 flaskは5000番ポートで受け付けるようにしているので注意してください

--- a/app.py
+++ b/app.py
@@ -32,6 +32,22 @@ def users():
     if request.method == 'POST':
         name = request.form.get('name')
         email = request.form.get('email')
+        db_type = request.form.get('db_type')
+        if db_type == 'postgresql':
+            app.config['SQLALCHEMY_DATABASE_URI'] = 'postgresql+psycopg2://{user}:{password}@{host}/{db-name}'.format(**{
+                'user': os.getenv('USERNAME'),
+                'password': os.getenv('PASSWORD'),
+                'host': os.getenv('HOST'),
+                'db-name': os.getenv('DB_NAME'),
+            })
+        else:
+            app.config['SQLALCHEMY_DATABASE_URI'] = 'mysql+pymysql://{user}:{password}@{host}/{db-name}?charset=utf8'.format(**{
+                'user': os.getenv('USERNAME'),
+                'password': os.getenv('PASSWORD'),
+                'host': os.getenv('HOST'),
+                'db-name': os.getenv('DB_NAME'),
+            })
+        db.create_all()
         user = User(name=name, email=email)
         db.session.add(user)
         db.session.commit()

--- a/app.py
+++ b/app.py
@@ -1,18 +1,34 @@
-import os
 from flask import Flask, request, jsonify, render_template
 from flask_cors import CORS
 from flask_sqlalchemy import SQLAlchemy
-from config import SQLALCHEMY_DATABASE_URI
+import os
 
 app = Flask(__name__)
 CORS(app)
-app.config['SQLALCHEMY_DATABASE_URI'] = SQLALCHEMY_DATABASE_URI
 app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
 
-db = SQLAlchemy(app)
+db = None
 
 @app.before_request
 def before_request():
+    global db
+    if db is None:
+        db_type = request.form.get('db_type', 'mysql')
+        if db_type == 'postgresql':
+            app.config['SQLALCHEMY_DATABASE_URI'] = 'postgresql+psycopg2://{user}:{password}@{host}/{db-name}'.format(**{
+                'user': os.getenv('USERNAME'),
+                'password': os.getenv('PASSWORD'),
+                'host': os.getenv('HOST'),
+                'db-name': os.getenv('DB_NAME'),
+            })
+        else:
+            app.config['SQLALCHEMY_DATABASE_URI'] = 'mysql+pymysql://{user}:{password}@{host}/{db-name}?charset=utf8'.format(**{
+                'user': os.getenv('USERNAME'),
+                'password': os.getenv('PASSWORD'),
+                'host': os.getenv('HOST'),
+                'db-name': os.getenv('DB_NAME'),
+            })
+        db = SQLAlchemy(app)
     db.create_all()
 
 class User(db.Model):

--- a/app.py
+++ b/app.py
@@ -1,3 +1,4 @@
+import os
 from flask import Flask, request, jsonify, render_template
 from flask_cors import CORS
 from flask_sqlalchemy import SQLAlchemy

--- a/config.py
+++ b/config.py
@@ -1,8 +1,18 @@
 import os
 
-SQLALCHEMY_DATABASE_URI = 'mysql+pymysql://{user}:{password}@{host}/{db-name}?charset=utf8'.format(**{
-    'user': os.getenv('USERNAME'),
-    'password': os.getenv('PASSWORD'),
-    'host': os.getenv('HOST'),
-    'db-name': os.getenv('DB_NAME'),
+db_type = os.getenv('DB_TYPE', 'mysql')
+
+if db_type == 'postgresql':
+    SQLALCHEMY_DATABASE_URI = 'postgresql+psycopg2://{user}:{password}@{host}/{db-name}'.format(**{
+        'user': os.getenv('USERNAME'),
+        'password': os.getenv('PASSWORD'),
+        'host': os.getenv('HOST'),
+        'db-name': os.getenv('DB_NAME'),
+    })
+else:
+    SQLALCHEMY_DATABASE_URI = 'mysql+pymysql://{user}:{password}@{host}/{db-name}?charset=utf8'.format(**{
+        'user': os.getenv('USERNAME'),
+        'password': os.getenv('PASSWORD'),
+        'host': os.getenv('HOST'),
+        'db-name': os.getenv('DB_NAME'),
     })

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,4 @@ PyMySQL==1.1.1
 SQLAlchemy==2.0.37
 typing_extensions==4.12.2
 Werkzeug==3.1.3
+psycopg2==2.9.6

--- a/templates/index.html
+++ b/templates/index.html
@@ -7,6 +7,12 @@
   <body>
     <h1>おためし接続</h1>
     <form action="/users" method="POST">
+      <label for="db_type">Database Type:</label>
+      <select name="db_type" id="db_type">
+        <option value="mysql">MySQL</option>
+        <option value="postgresql">PostgreSQL</option>
+      </select>
+      <br />
       <label for="name">Name:</label>
       <input type="text" name="name" id="name" />
       <br />


### PR DESCRIPTION
Add support for PostgreSQL alongside MySQL.

* **config.py**: Add a check for the `DB_TYPE` environment variable to determine the database type and set the `SQLALCHEMY_DATABASE_URI` accordingly.
* **requirements.txt**: Add `psycopg2` to the list of dependencies for PostgreSQL support.
* **README.md**: Add instructions for setting the `DB_TYPE` environment variable to either `mysql` or `postgresql`.
* **templates/index.html**: Add a dropdown menu to select either MySQL or PostgreSQL and update the form to include the selected database type.
* **app.py**: Update the `/users` route to handle the selected database type from the form and update the `before_request` function to use the selected database type.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/splattools/easydbaccess/pull/3?shareId=cfe34a70-8e16-4a82-8b46-872d9bbaaecc).